### PR TITLE
Complete Python 2 & 3 Compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export FACE_USERS=Alice,Bob,Casey,Doug
 To install [OpenCV](http://opencv.org) run:
 
 ```
-sudo apt-get install libopencv-dev python-opencv)
+sudo apt-get install libopencv-dev python-opencv
 ```
 
 If you are using virtual environments you will need to need to copy

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository contains tools to setup and train the [facial recognition module
 
 # Facetrainer Tool
 
-The scripts in this directory are based on scripts from [pi-facerec-box](https://github.com/tdicola/pi-facerec-box) and should be used on a computer (with a webcam). You need OpenCV installed on your computer. It may work on a Pi but is probably pretty slow.
+The scripts in this directory are based on scripts from [pi-facerec-box](https://github.com/tdicola/pi-facerec-box) and should be used on a computer (with a webcam). You need OpenCV installed on your computer. It works on a RaspberryPi.
 
 ## Usage
 ### Capturing training images
@@ -38,7 +38,37 @@ export FACE_USERS=Alice,Bob,Casey,Doug
 5. Run `python facerecognition.py`.
 
 ## Dependencies
-- [OpenCV](http://opencv.org) (sudo apt-get install libopencv-dev python-opencv)
+
+### OpenCV
+
+To install [OpenCV](http://opencv.org) run:
+
+```
+sudo apt-get install libopencv-dev python-opencv)
+```
+
+If you are using virtual environments you will need to need to copy
+the opencv python modules into your virutal environment path. That
+will look something like this:
+
+```
+cp /usr/lib/python2.7/dist-packages/cv* ~/.virtualenvs/MY_VIRTUAL_ENV/lib/python2.7/site-packages/
+```
+
+Where ``python2.7`` will be the name of your python version where
+opencv was installed and ``MY_VIRTUAL_ENV`` is the name of your
+virtual environment.
+
+### Python dependancies
+
+Install the required python packages. 
+
+```
+pip install -r requirements.txt
+```
+
+Currently this is just the ``future`` module for making the scripts python 2 and 3 cross compatible.
+
 
 ## Open Source Licenses
 ###[pi-facerec-box](https://github.com/tdicola/pi-facerec-box)

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,17 @@
 # TODO
 
-## Python 3 support
+## Python 3 support EXPERIMENTAL
 
-* PARTIAL: run py2to3 conversion on code (mostly done. still some possible issues with raw_input() calls)
+* DONE run py2to3 conversion on code 
+* DONE removed raw_imput
+* DONE test on python 2
+* TODO test on python 3
 
-## opencv 3 support
+## opencv 3 support INCOMPLETE
 
 * DONE (but untested) detect opencv version 2 or 3 and use appropriates  sub-modules [start with this patch](https://github.com/falgard/MMM-Facial-Recognition-Tools/commit/06b303190893e5e6dddf35bd1a67f88abb8683b6) 
 * DONE harvest other changes from [falgard](https://github.com/falgard/MMM-Facial-Recognition-Tools/commits/master)
+* TODO 
 
 ## capture.py and lib/capture.py
 

--- a/capture.py
+++ b/capture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # coding: utf8
 """MMM-Facial-Recognition - MagicMirror Module
 Face Recognition image capture script
@@ -18,19 +18,22 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 import lib.capture as capture
 import lib.config as config
 
+# to install builtins run `pip install future` 
+from builtins import input
+
 # set preview to False to disable picamera preview
 preview = True
 
 print("What do you want to do?")
 print("[1] Capture training images from webcam")
 print("[2] Convert '*.jpg' pictures from other cameras to training images")
-choice = raw_input("--> ")
+choice = int(input("--> "))
 print("")
 print("Enter the name of the person you want to capture or convert images for.")
-capture.CAPTURE_DIR = raw_input("--> ")
+capture.CAPTURE_DIR = str(input("--> "))
 print("Images will be placed in " + config.TRAINING_DIR + capture.CAPTURE_DIR)
 
-if choice == "1":
+if choice == 1:
     print("")
     print('-' * 20)
     print("Starting process...")
@@ -39,7 +42,7 @@ if choice == "1":
 else:
     print("")
     print("Please enter path to images or drag and drop folder into terminal")
-    capture.RAW_DIR = raw_input("--> ")
+    capture.RAW_DIR = str(input("--> "))
     print("")
     print('-' * 20)
     print("Starting process...")

--- a/lib/capture.py
+++ b/lib/capture.py
@@ -8,6 +8,8 @@ Based on work by Tony DiCola (Copyright 2013) (MIT License)
 Run this script to capture positive images for training the face recognizer.
 """
 from __future__ import division
+# need to run `pip install future` for builtins (python 2 & 3 compatibility)
+from   builtins import input
 
 import fnmatch
 import glob

--- a/train.py
+++ b/train.py
@@ -22,6 +22,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 import fnmatch
 import os
 
+# to install builtins run `pip install future` 
+from builtins import input
+
 import cv2
 import numpy as np
 
@@ -33,7 +36,7 @@ print("[1] LBPHF (recommended)")
 print("[2] Fisherfaces")
 print("[3] Eigenfaces")
 
-algorithm_choice = int(raw_input("--> "))
+algorithm_choice = int(input("--> "))
 print('')
 
 


### PR DESCRIPTION
So I introduced a bug while trying to add python 2 and 3 compatibility. It resulted in the following issue:

https://github.com/paviro/MMM-Facial-Recognition-Tools/issues/18

I did some more research and figured out how to correctly do python 2/3 compatible ``input()`` calls. The downside is it requires installing the python ``future`` module using ``pip`` I updated the README.md to reflect this. (and left clues in the source code if someone ignores the README.md instructions)

I did a full end-to-end test using python2. 

I did NOT do a test using python3 because this requires getting a working python 3 + openCV environment. Which is just stupid hard. I think I have completely  destroyed my OpenCV install on my mac and refuse to touch the install on my Pi as it took days to sort it out. *sigh*



