### PR TITLE
Changed CV2-version-check to not fail on shorter CV2-Version

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -12,7 +12,7 @@ import os
 import platform
 import cv2
 
-(CV_MAJOR_VER, CV_MINOR_VER, mv1, mv2) = cv2.__version__.split(".")
+(CV_MAJOR_VER, CV_MINOR_VER) = cv2.__version__.split(".")[:2]
 
 _platform = platform.system().lower()
 path_to_file = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))


### PR DESCRIPTION
So my CV2-Version is 

    >>> cv2.__version__
    '3.1.0'



This results in an ValueError:


    osmc@osmc ~/w/MMM-Facial-Recognition-Tools> python3 ./capture.py
    Traceback (most recent call last):
      File "./capture.py", line 18, in <module>
        import lib.capture as capture
      File "/home/osmc/workspace/MMM-Facial-Recognition-Tools/lib/capture.py", line 21, in <module>
        from . import config
      File "/home/osmc/workspace/MMM-Facial-Recognition-Tools/lib/config.py", line 15, in <module>
        (CV_MAJOR_VER, CV_MINOR_VER, mv1, mv2) = cv2.__version__.split(".")
    ValueError: need more than 3 values to unpack
    


Just checking for CV_MAJOR_VER and CV_MINOR_VER should be good, script is only checking CV_MAJOR_VER though.